### PR TITLE
Add Tuya Cloud integration and disable Google OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,11 @@ REACT_APP_WEATHER_DEBUG=false
 # Optional: Fallback to mock data if API fails (default: false)
 VITE_WEATHER_FALLBACK_MOCK=false
 REACT_APP_WEATHER_FALLBACK_MOCK=false
+
+# Tuya Cloud API credentials
+VITE_TUYA_ACCESS_ID=your_tuya_access_id_here
+VITE_TUYA_ACCESS_SECRET=your_tuya_access_secret_here
+VITE_TUYA_DEVICE_ID=your_tuya_device_id_here
+
+# Toggle for Google OAuth (disabled by default)
+VITE_ENABLE_GOOGLE_OAUTH=false

--- a/.env.template
+++ b/.env.template
@@ -22,3 +22,11 @@ REACT_APP_WEATHER_DEBUG=false
 # Optional: Fallback to mock data if API fails (default: false)
 VITE_WEATHER_FALLBACK_MOCK=false
 REACT_APP_WEATHER_FALLBACK_MOCK=false
+
+# Tuya Cloud API credentials
+VITE_TUYA_ACCESS_ID=your_tuya_access_id_here
+VITE_TUYA_ACCESS_SECRET=your_tuya_access_secret_here
+VITE_TUYA_DEVICE_ID=your_tuya_device_id_here
+
+# Toggle for Google OAuth (disabled by default)
+VITE_ENABLE_GOOGLE_OAUTH=false

--- a/GOOGLE_OAUTH_DISABLED.md
+++ b/GOOGLE_OAUTH_DISABLED.md
@@ -1,0 +1,15 @@
+# Google OAuth Temporarily Disabled
+
+Google OAuth integration has been disabled to switch the app to Tuya
+Cloud for indoor data.
+
+## Re-enable Google OAuth
+
+1. Set `VITE_ENABLE_GOOGLE_OAUTH=true` in your `.env` file.
+2. Replace the `TuyaSensor` component in `src/HumidityHub.jsx` with the
+   original `IndoorTemperature` component.
+3. Ensure the Google environment variables from `.env.example.google`
+   are populated.
+
+After these changes, rebuild or restart the development server and the
+Google sign-in flow will be available again.

--- a/TUYA_SETUP.md
+++ b/TUYA_SETUP.md
@@ -1,0 +1,48 @@
+# Tuya Cloud Setup Guide
+
+This project uses Tuya Cloud to retrieve local temperature and humidity
+from your smart sensors. Follow these steps to configure the required
+credentials.
+
+1. **Create a Tuya IoT Platform account**
+   - Visit [https://iot.tuya.com](https://iot.tuya.com) and sign up.
+
+2. **Create a Cloud project**
+   - In the Tuya IoT Platform, open **Cloud > Development > Create Cloud Project**.
+   - Choose the data center closest to your region.
+   - Enable the **Device Status Notification** and **Smart Home Scene** APIs.
+
+3. **Obtain Access ID and Secret**
+   - After creating the project, go to the project details page.
+   - Record the **Access ID** and **Access Secret**. These values are
+     used as `VITE_TUYA_ACCESS_ID` and `VITE_TUYA_ACCESS_SECRET` in the
+     `.env` file.
+
+4. **Link your Tuya app**
+   - In the project details, find **Link Device > Link App Account**.
+   - Use the Tuya Smart or Smart Life mobile app to scan the QR code and
+     link your account. This grants the Cloud project access to your devices.
+
+5. **Find the Device ID**
+   - After linking, the **Device Management** section lists your devices.
+   - Copy the **Device ID** of the sensor providing temperature and
+     humidity. Set this as `VITE_TUYA_DEVICE_ID` in the `.env` file.
+
+6. **Configure environment variables**
+   - Copy `.env.template` to `.env` and populate the Tuya values:
+
+```
+VITE_TUYA_ACCESS_ID=your_access_id
+VITE_TUYA_ACCESS_SECRET=your_access_secret
+VITE_TUYA_DEVICE_ID=your_device_id
+```
+
+7. **Run the app**
+   - Start the development server with `npm run dev`.
+   - The app will use Tuya Cloud to display indoor temperature and humidity.
+
+## Re-enabling Google OAuth
+
+Google OAuth is disabled by default. To re-enable it, set
+`VITE_ENABLE_GOOGLE_OAUTH=true` in your `.env` file and restore the
+`IndoorTemperature` component in `HumidityHub.jsx`.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "setup-weather-ps": "powershell -ExecutionPolicy Bypass -File setup-weather-config.ps1",
     "test-weather": "node test-weather-config.js",
     "migrate-weather": "node migrate-to-weatherapi.js",
+    "test-tuya": "node test-tuya-integration.js",
     "android:init": "powershell -ExecutionPolicy Bypass -File android-framework/scripts/init-capacitor.ps1",
     "android:build": "powershell -ExecutionPolicy Bypass -File build-android.ps1",
     "android:build-release": "powershell -ExecutionPolicy Bypass -File build-android.ps1 -Release",

--- a/src/HumidityHub.jsx
+++ b/src/HumidityHub.jsx
@@ -11,7 +11,7 @@ import ComparisonResult from './components/ComparisonResult';
 import LocationPermission from './components/LocationPermission';
 import VentilationForecast from './components/VentilationForecast';
 import TemperatureForecast from './components/TemperatureForecast';
-import IndoorTemperature from './components/IndoorTemperature';
+import TuyaSensor from './components/TuyaSensor';
 
 export default function HumidityHub() {
   const [indoorTemp, setIndoorTemp] = useState(21);
@@ -28,7 +28,7 @@ export default function HumidityHub() {
   const [isForecastLoading, setIsForecastLoading] = useState(false);
   const [forecastError, setForecastError] = useState(null);
 
-  // Handle indoor temperature updates from the IndoorTemperature component
+  // Handle indoor temperature updates from the TuyaSensor component
   const handleIndoorTemperatureChange = useCallback((tempData) => {
     console.log('🏠 Indoor temperature updated:', tempData);
     setIndoorTemp(tempData.temperature);
@@ -271,7 +271,7 @@ export default function HumidityHub() {
 
       {activeTab === 'current' && (
         <>
-          <IndoorTemperature onTemperatureChange={handleIndoorTemperatureChange} />
+        <TuyaSensor onTemperatureChange={handleIndoorTemperatureChange} />
           
           <div className="grid grid-cols-1 gap-6">
             <ClimateDisplayCard title="Indoor Climate" icon={<Home className="h-5 w-5 text-slate-600" />} data={indoorData} isLoading={false} />

--- a/src/components/GoogleAuthButton.jsx
+++ b/src/components/GoogleAuthButton.jsx
@@ -20,6 +20,14 @@ import {
  * for Smart Device Management API access.
  */
 export default function GoogleAuthButton({ onAuthSuccess, onAuthError }) {
+  const isEnabled = (import.meta.env.VITE_ENABLE_GOOGLE_OAUTH || process.env.VITE_ENABLE_GOOGLE_OAUTH) === 'true';
+  if (!isEnabled) {
+    return (
+      <div className="p-4 text-center text-sm text-gray-500">
+        Google OAuth is disabled.
+      </div>
+    );
+  }
   const signInButtonRef = useRef(null);
   const [authState, setAuthState] = useState({
     isConfigured: false,

--- a/src/components/TuyaSensor.jsx
+++ b/src/components/TuyaSensor.jsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useState } from 'react';
+import { Card, CardHeader, CardTitle, CardContent } from './ui/card';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Label } from './ui/label';
+import { Alert, AlertDescription } from './ui/alert';
+import { getLocalTemperatureHumidity } from '../integrations/TuyaAuth';
+
+/**
+ * TuyaSensor Component
+ *
+ * Retrieves indoor temperature and humidity from Tuya Cloud. If the
+ * data cannot be retrieved, the user can manually enter values.
+ */
+export default function TuyaSensor({ onTemperatureChange }) {
+  const [temperatureData, setTemperatureData] = useState(null);
+  const [error, setError] = useState(null);
+  const [manualTemp, setManualTemp] = useState('');
+  const [manualHumidity, setManualHumidity] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    fetchFromTuya();
+  }, []);
+
+  const fetchFromTuya = async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const data = await getLocalTemperatureHumidity();
+      const payload = {
+        temperature: data.temperature,
+        humidity: data.humidity,
+        source: 'tuya',
+        timestamp: new Date(),
+        lastUpdated: new Date()
+      };
+      setTemperatureData(payload);
+      if (onTemperatureChange) {
+        onTemperatureChange(payload);
+      }
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleManualSubmit = () => {
+    const t = parseFloat(manualTemp);
+    const h = manualHumidity ? parseFloat(manualHumidity) : null;
+    if (isNaN(t)) {
+      setError('Please enter a valid temperature');
+      return;
+    }
+    const payload = {
+      temperature: t,
+      humidity: h,
+      source: 'manual',
+      timestamp: new Date(),
+      lastUpdated: new Date()
+    };
+    setTemperatureData(payload);
+    setError(null);
+    if (onTemperatureChange) {
+      onTemperatureChange(payload);
+    }
+  };
+
+  if (isLoading) {
+    return <div className="p-4 text-center">Loading indoor data...</div>;
+  }
+
+  return (
+    <Card className="max-w-md mx-auto">
+      <CardHeader>
+        <CardTitle>Indoor Conditions</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {temperatureData ? (
+          <div className="text-center space-y-2">
+            <div className="text-4xl font-bold">{temperatureData.temperature}°C</div>
+            {temperatureData.humidity !== null && (
+              <div className="text-xl">Humidity: {temperatureData.humidity}%</div>
+            )}
+            <Button onClick={fetchFromTuya} className="mt-2" variant="secondary">Refresh</Button>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {error && (
+              <Alert variant="destructive">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+            <div>
+              <Label htmlFor="manualTemp">Temperature (°C)</Label>
+              <Input id="manualTemp" value={manualTemp} onChange={e => setManualTemp(e.target.value)} />
+            </div>
+            <div>
+              <Label htmlFor="manualHumidity">Humidity (%)</Label>
+              <Input id="manualHumidity" value={manualHumidity} onChange={e => setManualHumidity(e.target.value)} />
+            </div>
+            <Button onClick={handleManualSubmit}>Submit</Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/integrations/GoogleAuth.js
+++ b/src/integrations/GoogleAuth.js
@@ -11,6 +11,7 @@
 
 class GoogleAuthConfig {
   constructor() {
+    this.enabled = (import.meta.env.VITE_ENABLE_GOOGLE_OAUTH || process.env.VITE_ENABLE_GOOGLE_OAUTH) === 'true';
     // OAuth 2.0 Configuration
     this.clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID || import.meta.env.REACT_APP_GOOGLE_CLIENT_ID;
     this.clientSecret = import.meta.env.VITE_GOOGLE_CLIENT_SECRET || import.meta.env.REACT_APP_GOOGLE_CLIENT_SECRET;
@@ -25,10 +26,10 @@ class GoogleAuthConfig {
     this.debugMode = (import.meta.env.VITE_GOOGLE_HOME_DEBUG || import.meta.env.REACT_APP_GOOGLE_HOME_DEBUG) === 'true';
     
     // Check configuration
-    this.isConfigured = !!(this.clientId && this.projectId);
+    this.isConfigured = this.enabled && !!(this.clientId && this.projectId);
     
     if (!this.isConfigured && this.debugMode) {
-      console.warn('⚠️  Google Home integration not configured. Set VITE_GOOGLE_CLIENT_ID and VITE_GOOGLE_DEVICE_ACCESS_PROJECT_ID in .env file');
+      console.warn('⚠️  Google Home integration disabled or not configured. Set VITE_ENABLE_GOOGLE_OAUTH=true and provide credentials to enable.');
     }
   }
 

--- a/src/integrations/TuyaAuth.js
+++ b/src/integrations/TuyaAuth.js
@@ -1,0 +1,109 @@
+import crypto from 'crypto';
+
+/**
+ * Tuya Cloud OAuth and Device Status Integration
+ *
+ * Provides helper functions to authenticate with Tuya Cloud and
+ * retrieve temperature and humidity from a specified device.
+ */
+class TuyaConfig {
+  constructor() {
+    this.accessId = import.meta?.env?.VITE_TUYA_ACCESS_ID || process.env.VITE_TUYA_ACCESS_ID;
+    this.accessSecret = import.meta?.env?.VITE_TUYA_ACCESS_SECRET || process.env.VITE_TUYA_ACCESS_SECRET;
+    this.deviceId = import.meta?.env?.VITE_TUYA_DEVICE_ID || process.env.VITE_TUYA_DEVICE_ID;
+    this.apiBaseUrl =
+      import.meta?.env?.VITE_TUYA_API_BASE_URL ||
+      process.env.VITE_TUYA_API_BASE_URL ||
+      'https://openapi.tuyaus.com';
+    this.debug = (import.meta?.env?.VITE_TUYA_DEBUG || process.env.VITE_TUYA_DEBUG) === 'true';
+    this.isConfigured = Boolean(this.accessId && this.accessSecret && this.deviceId);
+  }
+
+  log(...args) {
+    if (this.debug) {
+      console.log('[TuyaAuth]', ...args);
+    }
+  }
+
+  error(...args) {
+    console.error('[TuyaAuth Error]', ...args);
+  }
+}
+
+const config = new TuyaConfig();
+
+function signString(str) {
+  return crypto.createHmac('sha256', config.accessSecret).update(str, 'utf8').digest('hex').toUpperCase();
+}
+
+async function getAccessToken() {
+  if (!config.isConfigured) {
+    throw new Error('Tuya credentials not configured');
+  }
+
+  const t = Date.now().toString();
+  const sign = signString(config.accessId + t);
+
+  const res = await fetch(`${config.apiBaseUrl}/v1.0/token?grant_type=1`, {
+    method: 'GET',
+    headers: {
+      'client_id': config.accessId,
+      sign,
+      t,
+      'sign_method': 'HMAC-SHA256'
+    }
+  });
+
+  const data = await res.json();
+  if (!data.success) {
+    throw new Error('Failed to obtain Tuya token');
+  }
+  return data.result.access_token;
+}
+
+async function getDeviceStatus(token) {
+  const t = Date.now().toString();
+  const path = `/v1.0/devices/${config.deviceId}/status`;
+  const sign = signString(config.accessId + token + t);
+
+  const res = await fetch(`${config.apiBaseUrl}${path}`, {
+    method: 'GET',
+    headers: {
+      'client_id': config.accessId,
+      'sign': sign,
+      't': t,
+      'sign_method': 'HMAC-SHA256',
+      'access_token': token
+    }
+  });
+  const data = await res.json();
+  if (!data.success) {
+    throw new Error('Failed to fetch Tuya device status');
+  }
+  return data.result;
+}
+
+export async function getLocalTemperatureHumidity() {
+  const token = await getAccessToken();
+  const status = await getDeviceStatus(token);
+
+  const tempDp = status.find((d) => d.code === 'temp_current' || d.code === 'temp_value');
+  const humDp = status.find((d) => d.code === 'humidity_value' || d.code === 'humidity_current');
+  const temperature = tempDp ? tempDp.value / 10 : null; // Tuya reports temp x10
+  const humidity = humDp ? humDp.value : null;
+
+  return {
+    temperature,
+    humidity,
+    deviceId: config.deviceId,
+    timestamp: Date.now()
+  };
+}
+
+export const TuyaAuth = {
+  getLocalTemperatureHumidity,
+};
+
+export function getTuyaConfig() {
+  return { ...config };
+}

--- a/test-tuya-integration.js
+++ b/test-tuya-integration.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * Basic tests for Tuya Cloud integration
+ */
+async function runTests() {
+  console.log('🔌 Testing Tuya integration...');
+
+  process.env.VITE_TUYA_ACCESS_ID = 'abc';
+  process.env.VITE_TUYA_ACCESS_SECRET = 'secret';
+  process.env.VITE_TUYA_DEVICE_ID = 'device123';
+
+  // Mock fetch responses
+  global.fetch = async (url) => {
+    if (url.includes('/token')) {
+      return {
+        json: async () => ({ success: true, result: { access_token: 'test_token' } })
+      };
+    }
+    if (url.includes('/devices/')) {
+      return {
+        json: async () => ({
+          success: true,
+          result: [
+            { code: 'temp_current', value: 235 },
+            { code: 'humidity_value', value: 50 }
+          ]
+        })
+      };
+    }
+    return { json: async () => ({ success: false }) };
+  };
+
+  const { getLocalTemperatureHumidity } = await import('./src/integrations/TuyaAuth.js');
+
+  try {
+    const data = await getLocalTemperatureHumidity();
+    if (data.temperature === 23.5 && data.humidity === 50) {
+      console.log('✅ Tuya data parsed correctly');
+    } else {
+      console.error('❌ Incorrect data returned', data);
+    }
+  } catch (err) {
+    console.error('❌ Tuya integration failed', err);
+  }
+}
+
+runTests();


### PR DESCRIPTION
## Summary
- add Tuya Cloud OAuth helper and sensor retrieval
- display Tuya device temperature/humidity in new component
- add docs and env toggles to disable Google OAuth and guide re-enabling

## Testing
- `npm run test-tuya`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b441ca6dd4832bbc051d10802a4cdb